### PR TITLE
Added file-read-metadata global permissions

### DIFF
--- a/src/macos.rs
+++ b/src/macos.rs
@@ -22,6 +22,7 @@ static DEFAULT_RULE: &[u8] = b"\
 (allow process-fork)
 (allow sysctl*)
 (allow system*)
+(allow file-read-metadata)
 (system-network)
 ";
 


### PR DESCRIPTION
Allowing `file-read-metadata` for all processes shouldn't meaningfully allow exfiltration, nor provide other attack vectors.