### PR TITLE
`aarch64` support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: [self-hosted, linux, arm64]
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: [self-hosted, macos, arm64]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          profile: minimal
+
       - name: Test Stable
         run: cargo test
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0-or-later"
 edition = "2021"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-landlock = { git = "https://github.com/cd-work/rust-landlock" }
+landlock = { git = "https://github.com/phylum-dev/rust-landlock", branch = "andrea/nr-syscall-arm" }
 seccompiler = "0.2.0"
 libc = "0.2.132"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0-or-later"
 edition = "2021"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-landlock = { git = "https://github.com/phylum-dev/rust-landlock", branch = "andrea/nr-syscall-arm" }
+landlock = { git = "https://github.com/phylum-dev/rust-landlock" }
 seccompiler = "0.2.0"
 libc = "0.2.132"
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 //! Sandboxing errors.
 
 use std::error::Error as StdError;
+#[cfg(target_os = "macos")]
 use std::ffi::OsString;
 use std::fmt::{self, Display, Formatter};
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
- Changed dependency URI of `rust-landlock`
- Updated test matrix to include `aarch64` self-hosted runners

Actions are going to fail on Linux until phylum-dev/rust-landlock#1 is merged; we should re-dispatch them once reviews are approved and before merging.