### PR TITLE
Add environment variable filtering

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 //! assert!(result.is_err());
 //! ```
 
+use std::env;
 use std::path::PathBuf;
 
 use crate::error::Result;
@@ -86,6 +87,18 @@ pub enum Exception {
     /// always also require read access.
     ExecuteAndRead(PathBuf),
 
+    /// Allow reading an environment variable.
+    Environment(String),
+
     /// Allow networking.
     Networking,
+}
+
+/// Restrict access to environment variables.
+pub(crate) fn restrict_env_variables(exceptions: &[String]) {
+    // Invalid unicode will cause `env::vars()` to panic, so we don't have to worry
+    // about them getting ignored.
+    for (key, _) in env::vars().filter(|(key, _)| !exceptions.contains(key)) {
+        env::remove_var(key);
+    }
 }

--- a/tests/env.rs
+++ b/tests/env.rs
@@ -1,0 +1,21 @@
+use std::env;
+
+use birdcage::{Birdcage, Exception, Sandbox};
+
+#[test]
+fn partial_fs() {
+    // Setup our environment variables
+    env::set_var("PUBLIC", "GOOD");
+    env::set_var("PRIVATE", "BAD");
+
+    // Activate our sandbox.
+    let mut birdcage = Birdcage::new().unwrap();
+    birdcage.add_exception(Exception::Environment("PUBLIC".into())).unwrap();
+    birdcage.lock().unwrap();
+
+    // The `PUBLIC` environment variable can be accessed.
+    assert_eq!(env::var("PUBLIC"), Ok("GOOD".into()));
+
+    // The `PRIVATE` environment variable was removed.
+    assert_eq!(env::var_os("PRIVATE"), None);
+}


### PR DESCRIPTION
This adds some super trivial handling for environment variables to the
sandbox, simply by removing any variable that isn't part of the
exception list.

See phylum-dev/cli#703.