### PR TITLE
Add mount namespaces to linux sandbox

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,11 @@ name = "net_without_namespaces"
 path = "tests/net_without_namespaces.rs"
 harness = false
 
+[[test]]
+name = "consistent_id_mappings"
+path = "tests/consistent_id_mappings.rs"
+harness = false
+
 [target.'cfg(target_os = "linux")'.dependencies]
 seccompiler = "0.2.0"
 landlock = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,11 @@ path = "tests/fs.rs"
 harness = false
 
 [[test]]
+name = "fs_without_landlock"
+path = "tests/fs_without_landlock.rs"
+harness = false
+
+[[test]]
 name = "full_env"
 path = "tests/full_env.rs"
 harness = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,12 @@ pub trait Sandbox: Sized {
     /// # Errors
     ///
     /// Sandboxing will fail if the calling process is not single-threaded.
+    ///
+    /// Since sandboxing layers are applied in multiple steps, it is possible
+    /// that after a failure some restrictions are still applied. While this
+    /// never allows the process to do things it wasn't capable of doing
+    /// before, it is still recommended to abort the sandboxing process if
+    /// you want to continue operations without a sandbox in place.
     fn lock(self) -> Result<()>;
 }
 

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -3,10 +3,6 @@
 //! This module implements sandboxing on Linux based on the Landlock LSM,
 //! namespaces, and seccomp.
 
-use std::fs;
-use std::io::Error as IoError;
-
-use bitflags::bitflags;
 use landlock::{
     make_bitflags, Access, AccessFs, Compatible, PathBeneath, PathFd, Ruleset, RulesetAttr,
     RulesetCreated, RulesetCreatedAttr, RulesetStatus, ABI as LANDLOCK_ABI,
@@ -16,6 +12,7 @@ use crate::error::{Error, Result};
 use crate::linux::seccomp::NetworkFilter;
 use crate::{Exception, Sandbox};
 
+mod namespaces;
 mod seccomp;
 
 /// Minimum landlock ABI version.
@@ -73,12 +70,15 @@ impl Sandbox for LinuxSandbox {
             crate::restrict_env_variables(&self.env_exceptions);
         }
 
-        // Clear abstract namespace by entering a new user namespace.
-        let _ = create_user_namespace(false);
+        // Setup namespaces.
+        let namespace_result = namespaces::create_namespaces(!self.allow_networking);
 
-        // Create network namespace.
+        // Setup seccomp network filter.
         if !self.allow_networking {
-            restrict_networking()?;
+            let seccomp_result = NetworkFilter::apply();
+
+            // Propagate failure if neither seccomp nor namespaces could isolate networking.
+            namespace_result.or(seccomp_result)?;
         }
 
         // Apply landlock rules.
@@ -90,101 +90,5 @@ impl Sandbox for LinuxSandbox {
         } else {
             Err(Error::ActivationFailed("sandbox could not be fully enforced".into()))
         }
-    }
-}
-
-/// Restrict networking using seccomp and namespaces.
-fn restrict_networking() -> Result<()> {
-    // Create network namespace.
-    let result = create_user_namespace(true).and_then(|_| unshare(Namespaces::NETWORK));
-
-    // Apply seccomp network filter.
-    let seccomp_result = NetworkFilter::apply();
-    result.or(seccomp_result)
-}
-
-/// Create a new user namespace.
-///
-/// If the `become_root` flag is set, then the current user will be mapped to
-/// UID 0 inside the namespace. Otherwise the current user will be mapped to its
-/// UID of the parent namespace.
-fn create_user_namespace(become_root: bool) -> Result<()> {
-    // Get the current UID/GID.
-    let uid = unsafe { libc::geteuid() };
-    let gid = unsafe { libc::getegid() };
-
-    // Create the namespace.
-    unshare(Namespaces::USER)?;
-
-    // Map the UID and GID.
-    let uid_map = if become_root { format!("0 {uid} 1\n") } else { format!("{uid} {uid} 1\n") };
-    let gid_map = if become_root { format!("0 {gid} 1\n") } else { format!("{gid} {gid} 1\n") };
-    fs::write("/proc/self/uid_map", uid_map.as_bytes())?;
-    fs::write("/proc/self/setgroups", b"deny")?;
-    fs::write("/proc/self/gid_map", gid_map.as_bytes())?;
-
-    Ok(())
-}
-
-/// Enter a namespace.
-fn unshare(namespaces: Namespaces) -> Result<()> {
-    let result = unsafe { libc::unshare(namespaces.bits()) };
-    if result == 0 {
-        Ok(())
-    } else {
-        Err(IoError::last_os_error().into())
-    }
-}
-
-bitflags! {
-    /// Unshare system call namespace flags.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    struct Namespaces: libc::c_int {
-        /// Unshare the file descriptor table, so that the calling process no longer
-        /// shares its file descriptors with any other process.
-        const FILES = libc::CLONE_FILES;
-        /// Unshare filesystem attributes, so that the calling process no longer shares
-        /// its root directory, current directory, or umask attributes with any other process.
-        const FS = libc::CLONE_FS;
-        /// Unshare the cgroup namespace.
-        const CGROUP = libc::CLONE_NEWCGROUP;
-        /// Unshare the IPC namespace, so that the calling process has a private copy of
-        /// the IPC namespace which is not shared with any other process. Specifying
-        /// this flag automatically implies [`Namespaces::SYSVSEM`] as well.
-        const IPC = libc::CLONE_NEWIPC;
-        /// Unshare the network namespace, so that the calling process is moved into a
-        /// new network namespace which is not shared with any previously existing process.
-        const NETWORK = libc::CLONE_NEWNET;
-        /// Unshare the mount namespace, so that the calling process has a private copy
-        /// of its namespace which is not shared with any other process. Specifying this
-        /// flag automatically implies [`Namespaces::FS`] as well.
-        const MOUNT = libc::CLONE_NEWNS;
-        /// Unshare the PID namespace, so that the calling process has a new PID
-        /// namespace for its children which is not shared with any previously existing
-        /// process. The calling process is **not** moved into the new namespace. The
-        /// first child created by the calling process will have the process ID 1 and
-        /// will assume the role of init in the new namespace. Specifying this flag
-        /// automatically implies [`libc::CLONE_THREAD`] as well.
-        const PID = libc::CLONE_NEWPID;
-        /// Unshare the time namespace, so that the calling process has a new time
-        /// namespace for its children which is not shared with any previously existing
-        /// process. The calling process is **not** moved into the new namespace.
-        const TIME = 0x80;
-        /// Unshare the user namespace, so that the calling process is moved into a new
-        /// user namespace which is not shared with any previously existing process. The
-        /// caller obtains a full set of capabilities in the new namespace.
-        ///
-        /// Requires that the calling process is not threaded; specifying this flag
-        /// automatically implies [`libc::CLONE_THREAD`] and [`Namespaces::FS`] as well.
-        const USER = libc::CLONE_NEWUSER;
-        /// Unshare the UTS IPC namespace, so that the calling process has a private
-        /// copy of the UTS namespace which is not shared with any other process.
-        const UTS = libc::CLONE_NEWUTS;
-        /// Unshare System V semaphore adjustment (semadj) values, so that the calling
-        /// process has a new empty semadj list that is not shared with any other
-        /// process. If this is the last process that has a reference to the process's
-        /// current semadj list, then the adjustments in that list are applied to the
-        /// corresponding semaphores
-        const SYSVSEM = libc::CLONE_SYSVSEM;
     }
 }

--- a/src/linux/namespaces.rs
+++ b/src/linux/namespaces.rs
@@ -29,7 +29,7 @@ const OLD_ROOT_DIR: &str = "birdcage-old-root";
 ///
 /// If successful, this will always clear the abstract namespace.
 ///
-/// Additionally it will isolate network access if `deny_networking` is `true`.
+/// Additionally it will isolate network access if `allow_networking` is `false`.
 pub fn create_namespaces(
     allow_networking: bool,
     bind_mounts: HashMap<PathBuf, libc::c_ulong>,
@@ -89,7 +89,7 @@ fn create_mount_namespace(bind_mounts: HashMap<PathBuf, libc::c_ulong>) -> Resul
     // Bind mount all allowed directories.
     let current_dir = env::current_dir().ok();
     for (mut path, flags) in bind_mounts {
-        // Ensure all paths are relative.
+        // Ensure all paths are absolute.
         if path.is_relative() {
             let current_dir = match &current_dir {
                 Some(current_dir) => current_dir,

--- a/src/linux/namespaces.rs
+++ b/src/linux/namespaces.rs
@@ -387,7 +387,7 @@ fn absolute(path: &Path) -> io::Result<PathBuf> {
     // Get the components, skipping the redundant leading "." component if it
     // exists.
     let mut components = path.strip_prefix(".").unwrap_or(path).components();
-    let path_os = path.as_os_str().as_encoded_bytes();
+    let path_os = path.as_os_str().as_bytes();
 
     let mut normalized = if path.is_absolute() {
         // "If a pathname begins with two successive <slash> characters, the

--- a/src/linux/namespaces.rs
+++ b/src/linux/namespaces.rs
@@ -65,7 +65,9 @@ fn create_mount_namespace(bind_mounts: HashMap<PathBuf, libc::c_ulong>) -> Resul
     let put_old = new_root.join(OLD_ROOT_DIR);
 
     // Ensure new root is available as an empty directory.
-    fs::remove_dir_all(&new_root)?;
+    if new_root.exists() {
+        fs::remove_dir_all(&new_root)?;
+    }
     fs::create_dir(&new_root)?;
 
     // Create C-friendly versions for our paths.

--- a/src/linux/namespaces.rs
+++ b/src/linux/namespaces.rs
@@ -1,0 +1,116 @@
+//! Linux namespaces.
+
+use std::fs;
+use std::io::Error as IoError;
+
+use bitflags::bitflags;
+
+use crate::error::Result;
+
+/// Isolate process using Linux namespaces.
+///
+/// If successful, this will always clear the abstract namespace.
+///
+/// Additionally it will isolate network access if `deny_networking` is `true`.
+pub fn create_namespaces(deny_networking: bool) -> Result<()> {
+    // Get EUID/EGID outside of the namespace.
+    let uid = unsafe { libc::geteuid() };
+    let gid = unsafe { libc::getegid() };
+
+    // Setup the network namespace.
+    if deny_networking {
+        create_user_namespace(uid, gid, 0, 0, Namespaces::NETWORK)?;
+    }
+
+    // Drop root user mapping and ensure abstract namespace is cleared.
+    create_user_namespace(uid, gid, uid, gid, Namespaces::empty())?;
+
+    Ok(())
+}
+
+/// Create a new user namespace.
+///
+/// The parent and child UIDs and GIDs define the user and group mappings
+/// between the parent namespace and the new user namespace.
+fn create_user_namespace(
+    parent_uid: u32,
+    parent_gid: u32,
+    child_uid: u32,
+    child_gid: u32,
+    extra_namespaces: Namespaces,
+) -> Result<()> {
+    // Create the namespace.
+    unshare(Namespaces::USER | extra_namespaces)?;
+
+    // Map the UID and GID.
+    let uid_map = format!("{child_uid} {parent_uid} 1\n");
+    let gid_map = format!("{child_gid} {parent_gid} 1\n");
+    fs::write("/proc/self/uid_map", uid_map.as_bytes())?;
+    fs::write("/proc/self/setgroups", b"deny")?;
+    fs::write("/proc/self/gid_map", gid_map.as_bytes())?;
+
+    Ok(())
+}
+
+/// Enter a namespace.
+fn unshare(namespaces: Namespaces) -> Result<()> {
+    let result = unsafe { libc::unshare(namespaces.bits()) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(IoError::last_os_error().into())
+    }
+}
+
+bitflags! {
+    /// Unshare system call namespace flags.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+    struct Namespaces: libc::c_int {
+        /// Unshare the file descriptor table, so that the calling process no longer
+        /// shares its file descriptors with any other process.
+        const FILES = libc::CLONE_FILES;
+        /// Unshare filesystem attributes, so that the calling process no longer shares
+        /// its root directory, current directory, or umask attributes with any other process.
+        const FS = libc::CLONE_FS;
+        /// Unshare the cgroup namespace.
+        const CGROUP = libc::CLONE_NEWCGROUP;
+        /// Unshare the IPC namespace, so that the calling process has a private copy of
+        /// the IPC namespace which is not shared with any other process. Specifying
+        /// this flag automatically implies [`Namespaces::SYSVSEM`] as well.
+        const IPC = libc::CLONE_NEWIPC;
+        /// Unshare the network namespace, so that the calling process is moved into a
+        /// new network namespace which is not shared with any previously existing process.
+        const NETWORK = libc::CLONE_NEWNET;
+        /// Unshare the mount namespace, so that the calling process has a private copy
+        /// of its namespace which is not shared with any other process. Specifying this
+        /// flag automatically implies [`Namespaces::FS`] as well.
+        const MOUNT = libc::CLONE_NEWNS;
+        /// Unshare the PID namespace, so that the calling process has a new PID
+        /// namespace for its children which is not shared with any previously existing
+        /// process. The calling process is **not** moved into the new namespace. The
+        /// first child created by the calling process will have the process ID 1 and
+        /// will assume the role of init in the new namespace. Specifying this flag
+        /// automatically implies [`libc::CLONE_THREAD`] as well.
+        const PID = libc::CLONE_NEWPID;
+        /// Unshare the time namespace, so that the calling process has a new time
+        /// namespace for its children which is not shared with any previously existing
+        /// process. The calling process is **not** moved into the new namespace.
+        const TIME = 0x80;
+        /// Unshare the user namespace, so that the calling process is moved into a new
+        /// user namespace which is not shared with any previously existing process. The
+        /// caller obtains a full set of capabilities in the new namespace.
+        ///
+        /// Requires that the calling process is not threaded; specifying this flag
+        /// automatically implies [`libc::CLONE_THREAD`] and [`Namespaces::FS`] as well.
+        const USER = libc::CLONE_NEWUSER;
+        /// Unshare the UTS IPC namespace, so that the calling process has a private
+        /// copy of the UTS namespace which is not shared with any other process.
+        const UTS = libc::CLONE_NEWUTS;
+        /// Unshare System V semaphore adjustment (semadj) values, so that the calling
+        /// process has a new empty semadj list that is not shared with any other
+        /// process. If this is the last process that has a reference to the process's
+        /// current semadj list, then the adjustments in that list are applied to the
+        /// corresponding semaphores
+        const SYSVSEM = libc::CLONE_SYSVSEM;
+    }
+}

--- a/src/linux/namespaces.rs
+++ b/src/linux/namespaces.rs
@@ -64,10 +64,9 @@ fn create_mount_namespace(bind_mounts: HashMap<PathBuf, libc::c_ulong>) -> Resul
     let new_root = PathBuf::from(NEW_ROOT);
     let put_old = new_root.join(OLD_ROOT_DIR);
 
-    // Ensure new root exists.
-    if !new_root.exists() {
-        fs::create_dir(&new_root)?;
-    }
+    // Ensure new root is available as an empty directory.
+    fs::remove_dir_all(&new_root)?;
+    fs::create_dir(&new_root)?;
 
     // Create C-friendly versions for our paths.
     let new_root_c = CString::new(new_root.as_os_str().as_bytes()).unwrap();

--- a/tests/consistent_id_mappings.rs
+++ b/tests/consistent_id_mappings.rs
@@ -1,5 +1,7 @@
+#[cfg(target_os = "linux")]
 use birdcage::{Birdcage, Sandbox};
 
+#[cfg(target_os = "linux")]
 fn main() {
     let uid = unsafe { libc::getuid() };
     let gid = unsafe { libc::getgid() };
@@ -14,3 +16,6 @@ fn main() {
     assert_eq!(euid, unsafe { libc::geteuid() });
     assert_eq!(egid, unsafe { libc::getegid() });
 }
+
+#[cfg(not(target_os = "linux"))]
+fn main() {}

--- a/tests/consistent_id_mappings.rs
+++ b/tests/consistent_id_mappings.rs
@@ -1,0 +1,16 @@
+use birdcage::{Birdcage, Sandbox};
+
+fn main() {
+    let uid = unsafe { libc::getuid() };
+    let gid = unsafe { libc::getgid() };
+    let euid = unsafe { libc::geteuid() };
+    let egid = unsafe { libc::getegid() };
+
+    let birdcage = Birdcage::new().unwrap();
+    birdcage.lock().unwrap();
+
+    assert_eq!(uid, unsafe { libc::getuid() });
+    assert_eq!(gid, unsafe { libc::getgid() });
+    assert_eq!(euid, unsafe { libc::geteuid() });
+    assert_eq!(egid, unsafe { libc::getegid() });
+}

--- a/tests/exec.rs
+++ b/tests/exec.rs
@@ -7,6 +7,8 @@ fn main() {
     let mut birdcage = Birdcage::new().unwrap();
     birdcage.add_exception(Exception::ExecuteAndRead("/usr/bin/true".into())).unwrap();
     birdcage.add_exception(Exception::ExecuteAndRead("/usr/lib".into())).unwrap();
+    birdcage.add_exception(Exception::ExecuteAndRead("/lib64".into())).unwrap();
+    birdcage.add_exception(Exception::ExecuteAndRead("/lib".into())).unwrap();
     birdcage.lock().unwrap();
 
     // Check for success when executing `true`.

--- a/tests/exec.rs
+++ b/tests/exec.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::PathBuf;
 use std::process::Command;
 
 use birdcage::{Birdcage, Exception, Sandbox};
@@ -7,8 +8,12 @@ fn main() {
     let mut birdcage = Birdcage::new().unwrap();
     birdcage.add_exception(Exception::ExecuteAndRead("/usr/bin/true".into())).unwrap();
     birdcage.add_exception(Exception::ExecuteAndRead("/usr/lib".into())).unwrap();
-    birdcage.add_exception(Exception::ExecuteAndRead("/lib64".into())).unwrap();
-    birdcage.add_exception(Exception::ExecuteAndRead("/lib".into())).unwrap();
+    if PathBuf::from("/lib64").exists() {
+        birdcage.add_exception(Exception::ExecuteAndRead("/lib64".into())).unwrap();
+    }
+    if PathBuf::from("/lib64").exists() {
+        birdcage.add_exception(Exception::ExecuteAndRead("/lib".into())).unwrap();
+    }
     birdcage.lock().unwrap();
 
     // Check for success when executing `true`.

--- a/tests/exec.rs
+++ b/tests/exec.rs
@@ -11,7 +11,7 @@ fn main() {
     if PathBuf::from("/lib64").exists() {
         birdcage.add_exception(Exception::ExecuteAndRead("/lib64".into())).unwrap();
     }
-    if PathBuf::from("/lib64").exists() {
+    if PathBuf::from("/lib").exists() {
         birdcage.add_exception(Exception::ExecuteAndRead("/lib".into())).unwrap();
     }
     birdcage.lock().unwrap();

--- a/tests/fs_without_landlock.rs
+++ b/tests/fs_without_landlock.rs
@@ -17,6 +17,7 @@ const ARCH: TargetArch = TargetArch::x86_64;
 #[cfg(target_arch = "aarch64")]
 const ARCH: TargetArch = TargetArch::aarch64;
 
+#[cfg(target_os = "linux")]
 fn main() {
     const FILE_CONTENT: &str = "expected content";
 
@@ -52,3 +53,6 @@ fn main() {
     let result = fs::read_to_string(private_path);
     assert!(result.is_err());
 }
+
+#[cfg(not(target_os = "linux"))]
+fn main() {}

--- a/tests/fs_without_landlock.rs
+++ b/tests/fs_without_landlock.rs
@@ -1,0 +1,61 @@
+#[cfg(target_os = "linux")]
+use std::collections::BTreeMap;
+#[cfg(target_os = "linux")]
+use std::fs;
+
+#[cfg(target_os = "linux")]
+use birdcage::{Birdcage, Exception, Sandbox};
+#[cfg(target_os = "linux")]
+use seccompiler::{BpfProgram, SeccompAction, SeccompFilter, TargetArch};
+#[cfg(target_os = "linux")]
+use tempfile::NamedTempFile;
+
+#[cfg(target_os = "linux")]
+#[cfg(target_arch = "x86_64")]
+const ARCH: TargetArch = TargetArch::x86_64;
+#[cfg(target_os = "linux")]
+#[cfg(target_arch = "aarch64")]
+const ARCH: TargetArch = TargetArch::aarch64;
+
+fn main() {
+    const FILE_CONTENT: &str = "expected content";
+
+    // Create seccomp filter blocking `landlock_create_ruleset` syscall.
+    let mut rules = BTreeMap::new();
+    rules.insert(libc::SYS_landlock_restrict_self, Vec::new());
+    let filter = SeccompFilter::new(
+        rules,
+        SeccompAction::Allow,
+        SeccompAction::Errno(libc::EACCES as u32),
+        ARCH,
+    )
+    .unwrap();
+    let program: BpfProgram = filter.try_into().unwrap();
+    seccompiler::apply_filter(&program).unwrap();
+
+    // Setup our test files.
+    let private_path = NamedTempFile::new().unwrap();
+    fs::write(&private_path, FILE_CONTENT.as_bytes()).unwrap();
+    let public_path = NamedTempFile::new().unwrap();
+    fs::write(&public_path, FILE_CONTENT.as_bytes()).unwrap();
+
+    // Activate our sandbox.
+    let mut birdcage = Birdcage::new().unwrap();
+    birdcage.add_exception(Exception::Read(public_path.path().into())).unwrap();
+    let result = birdcage.lock();
+
+    match result {
+        // Namespaces are supported, so filesystem should still be restricted.
+        Ok(_) => (),
+        // Namespaces aren't supported, so failure is desired.
+        Err(_) => return,
+    }
+
+    // Access to the public file is allowed.
+    let content = fs::read_to_string(public_path).unwrap();
+    assert_eq!(content, FILE_CONTENT);
+
+    // Access to the private file is prohibited.
+    let result = fs::read_to_string(private_path);
+    assert!(result.is_err());
+}

--- a/tests/fs_without_landlock.rs
+++ b/tests/fs_without_landlock.rs
@@ -21,7 +21,7 @@ const ARCH: TargetArch = TargetArch::aarch64;
 fn main() {
     const FILE_CONTENT: &str = "expected content";
 
-    // Create seccomp filter blocking `landlock_create_ruleset` syscall.
+    // Create seccomp filter blocking `landlock_restrict_self` syscall.
     let mut rules = BTreeMap::new();
     rules.insert(libc::SYS_landlock_restrict_self, Vec::new());
     let filter = SeccompFilter::new(

--- a/tests/fs_without_landlock.rs
+++ b/tests/fs_without_landlock.rs
@@ -42,14 +42,7 @@ fn main() {
     // Activate our sandbox.
     let mut birdcage = Birdcage::new().unwrap();
     birdcage.add_exception(Exception::Read(public_path.path().into())).unwrap();
-    let result = birdcage.lock();
-
-    match result {
-        // Namespaces are supported, so filesystem should still be restricted.
-        Ok(_) => (),
-        // Namespaces aren't supported, so failure is desired.
-        Err(_) => return,
-    }
+    birdcage.lock().unwrap();
 
     // Access to the public file is allowed.
     let content = fs::read_to_string(public_path).unwrap();

--- a/tests/full_sandbox.rs
+++ b/tests/full_sandbox.rs
@@ -24,7 +24,7 @@ fn main() {
     drop(stream);
 
     // Ensure non-sandboxed execution works.
-    let cmd = Command::new("/bin/echo").arg("hello world").status();
+    let cmd = Command::new("/bin/true").status();
     assert!(cmd.is_ok());
 
     // Ensure non-sandboxed env access works.
@@ -48,7 +48,7 @@ fn main() {
     drop(stream);
 
     // Ensure sandboxed execution is blocked.
-    let cmd = Command::new("/bin/echo").arg("hello world").status();
+    let cmd = Command::new("/bin/true").status();
     assert!(cmd.is_err());
 
     // Ensure sandboxed env access is blocked.

--- a/tests/full_sandbox.rs
+++ b/tests/full_sandbox.rs
@@ -24,7 +24,7 @@ fn main() {
     drop(stream);
 
     // Ensure non-sandboxed execution works.
-    let cmd = Command::new("/bin/true").status();
+    let cmd = Command::new("/usr/bin/true").status();
     assert!(cmd.is_ok());
 
     // Ensure non-sandboxed env access works.
@@ -48,7 +48,7 @@ fn main() {
     drop(stream);
 
     // Ensure sandboxed execution is blocked.
-    let cmd = Command::new("/bin/true").status();
+    let cmd = Command::new("/usr/bin/true").status();
     assert!(cmd.is_err());
 
     // Ensure sandboxed env access is blocked.

--- a/tests/net_without_namespaces.rs
+++ b/tests/net_without_namespaces.rs
@@ -33,15 +33,14 @@ fn main() {
     let birdcage = Birdcage::new().unwrap();
     let result = birdcage.lock();
 
-    match result {
-        // Seccomp is supported, so networking should still be blocked.
-        Ok(_) => {
-            let result = TcpStream::connect("8.8.8.8:443");
-            assert!(result.is_err());
-        },
-        // Seccomp isn't supported, so failure is desired.
-        Err(_) => (),
+    // Seccomp isn't supported, so failure is desired.
+    if result.is_err() {
+        return;
     }
+
+    // Seccomp is supported, so networking should still be blocked.
+    let result = TcpStream::connect("8.8.8.8:443");
+    assert!(result.is_err());
 }
 
 #[cfg(not(target_os = "linux"))]


### PR DESCRIPTION
This patch adds optional mount namespaces to the linux sandbox to
allow for filesystem isolation on systems without landlock support.

Filesystem isolation now requires either landlock OR namespace creation
to be successful in order for the sandbox creation to be successful.

Landlock will be layered on top of the mount namespace if both are
available.

While landlock automatically resolves symlink access, mount namespaces
do not. So to allow access to `/usr/lib` through `/lib`, it is now
necessary to allow both `/lib` AND `/usr/lib`.