### PR TITLE
Fix root filesystem exceptions on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - (Linux) Report invalid paths when adding exceptions
 
+### Fixed
+
+- (Linux) Root filesystem exceptions failing sandbox creation
+
 ## [0.4.0] - 2023-10-09
 
 ### Added


### PR DESCRIPTION
This fixes an issue with filesystem exceptions on Linux where allowing
access to `/` would prevent creating the directory to put the old root
with `pivot_root`.

Instead, the old root is now mounted on top of the new root, removing
the necessity to create a separate directory for it. By immediately
unmounting the root, the old root then gets discarded and the new root
is accessible.