### PR TITLE
Fix readonly/noexec exceptions in Linux sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - (Linux) Root filesystem exceptions failing sandbox creation
+- (Linux) Sandbox not enforcing readonly/noexec restrictions
 
 ## [0.4.0] - 2023-10-09
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,11 @@ path = "tests/fs.rs"
 harness = false
 
 [[test]]
+name = "fs_readonly"
+path = "tests/fs_readonly.rs"
+harness = false
+
+[[test]]
 name = "full_env"
 path = "tests/full_env.rs"
 harness = false

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -5,7 +5,7 @@ use std::io::Error as IoError;
 use std::path::PathBuf;
 
 use crate::error::{Error, Result};
-use crate::linux::namespaces::MountFlags;
+use crate::linux::namespaces::MountAttrFlags;
 use crate::linux::seccomp::SyscallFilter;
 use crate::{Exception, Sandbox};
 
@@ -15,7 +15,7 @@ mod seccomp;
 /// Linux sandboxing.
 #[derive(Default)]
 pub struct LinuxSandbox {
-    bind_mounts: HashMap<PathBuf, MountFlags>,
+    bind_mounts: HashMap<PathBuf, MountAttrFlags>,
     env_exceptions: Vec<String>,
     allow_networking: bool,
     full_env: bool,
@@ -31,14 +31,14 @@ impl LinuxSandbox {
     /// permissions.
     fn update_bind_mount(&mut self, path: PathBuf, write: bool, execute: bool) {
         let flags =
-            self.bind_mounts.entry(path).or_insert(MountFlags::READONLY | MountFlags::NOEXEC);
+            self.bind_mounts.entry(path).or_insert(MountAttrFlags::RDONLY | MountAttrFlags::NOEXEC);
 
         if write {
-            flags.remove(MountFlags::READONLY);
+            flags.remove(MountAttrFlags::RDONLY);
         }
 
         if execute {
-            flags.remove(MountFlags::NOEXEC);
+            flags.remove(MountAttrFlags::NOEXEC);
         }
     }
 }

--- a/tests/fs_readonly.rs
+++ b/tests/fs_readonly.rs
@@ -1,0 +1,25 @@
+use std::fs;
+
+use birdcage::{Birdcage, Exception, Sandbox};
+use tempfile::NamedTempFile;
+
+fn main() {
+    const FILE_CONTENT: &str = "expected content";
+
+    // Setup the test file.
+    let file = NamedTempFile::new().unwrap();
+    fs::write(&file, FILE_CONTENT.as_bytes()).unwrap();
+
+    // Activate our sandbox.
+    let mut birdcage = Birdcage::new();
+    birdcage.add_exception(Exception::Read(file.path().into())).unwrap();
+    birdcage.lock().unwrap();
+
+    // Reading from the file is allowed.
+    let content = fs::read_to_string(&file).unwrap();
+    assert_eq!(content, FILE_CONTENT);
+
+    // Writing to the file is prohibited.
+    let result = fs::write(&file, FILE_CONTENT.as_bytes());
+    assert!(result.is_err());
+}


### PR DESCRIPTION
This fixes an issue where every path added as exception on Linux would allow for full write/exec privileges.

