### PR TITLE
Change `Write` exception to `WriteAndRead`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - (Linux) Report invalid paths when adding exceptions
+- `Exception::Write` changed to `Exception::WriteAndRead`
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,11 @@ path = "tests/fs_readonly.rs"
 harness = false
 
 [[test]]
+name = "fs_write_also_read"
+path = "tests/fs_write_also_read.rs"
+harness = false
+
+[[test]]
 name = "full_env"
 path = "tests/full_env.rs"
 harness = false

--- a/examples/sandbox.rs
+++ b/examples/sandbox.rs
@@ -49,7 +49,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     for path in cli.allow_write {
-        birdcage.add_exception(Exception::Write(path))?;
+        birdcage.add_exception(Exception::WriteAndRead(path))?;
     }
 
     for path in cli.allow_execute {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,9 +88,7 @@ pub enum Exception {
     /// Allow read access to the path and anything beneath it.
     Read(PathBuf),
 
-    /// Allow write access to the path and anything beneath it.
-    ///
-    /// On Linux this will **always** also grant read access to the path.
+    /// Allow writing and reading the path and anything beneath it.
     WriteAndRead(PathBuf),
 
     /// Allow executing and reading the path and anything beneath it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,9 @@ pub enum Exception {
     Read(PathBuf),
 
     /// Allow write access to the path and anything beneath it.
-    Write(PathBuf),
+    ///
+    /// On Linux this will **always** also grant read access to the path.
+    WriteAndRead(PathBuf),
 
     /// Allow executing and reading the path and anything beneath it.
     ///

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -50,8 +50,9 @@ impl Sandbox for LinuxSandbox {
 
     fn add_exception(&mut self, exception: Exception) -> Result<&mut Self> {
         // Report error if exception is added for an invalid path.
-        if let Exception::Read(path) | Exception::Write(path) | Exception::ExecuteAndRead(path) =
-            &exception
+        if let Exception::Read(path)
+        | Exception::WriteAndRead(path)
+        | Exception::ExecuteAndRead(path) = &exception
         {
             if !path.exists() {
                 return Err(Error::InvalidPath(path.into()));
@@ -60,7 +61,7 @@ impl Sandbox for LinuxSandbox {
 
         match exception {
             Exception::Read(path) => self.update_bind_mount(path, false, false),
-            Exception::Write(path) => self.update_bind_mount(path, true, false),
+            Exception::WriteAndRead(path) => self.update_bind_mount(path, true, false),
             Exception::ExecuteAndRead(path) => self.update_bind_mount(path, false, true),
             Exception::Environment(key) => self.env_exceptions.push(key),
             Exception::FullEnvironment => self.full_env = true,

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -51,7 +51,9 @@ impl Sandbox for MacSandbox {
                 buffer.write_all(escaped_path.as_bytes())?;
                 buffer.write_all(b"))\n")?;
             },
-            Exception::Write(path) => {
+            Exception::WriteAndRead(path) => {
+                self.add_exception(Exception::Read(path.clone()))?;
+
                 buffer.write_all(b"(allow file-write* (subpath ")?;
                 let escaped_path = escape_path(path)?;
                 buffer.write_all(escaped_path.as_bytes())?;

--- a/tests/fs_write_also_read.rs
+++ b/tests/fs_write_also_read.rs
@@ -1,0 +1,23 @@
+use std::fs;
+
+use birdcage::{Birdcage, Exception, Sandbox};
+use tempfile::NamedTempFile;
+
+fn main() {
+    const FILE_CONTENT: &str = "expected content";
+
+    // Setup our test files.
+    let file = NamedTempFile::new().unwrap();
+
+    // Activate our sandbox.
+    let mut birdcage = Birdcage::new();
+    birdcage.add_exception(Exception::WriteAndRead(file.path().into())).unwrap();
+    birdcage.lock().unwrap();
+
+    // Write access is allowed.
+    fs::write(&file, FILE_CONTENT.as_bytes()).unwrap();
+
+    // Read access is allowed.
+    let content = fs::read_to_string(file).unwrap();
+    assert_eq!(content, FILE_CONTENT);
+}


### PR DESCRIPTION
Since Linux will always allow read when write is granted, we copy its
behavior on macOS and also update the name to clarify this behavior.