### PR TITLE
Ignore lockdown errors for invalid paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - (macOS) Modifying exceptions for paths affected by existing exceptions
 - (Linux) Symlink/Canonical path's exceptions overriding each other
 - (Linux) PID namespace support
+- (Linux) Sandbox lockdown failing when deleting file after adding exception
 
 ## [v0.5.0] - 2023-10-13
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ harness = false
 [target.'cfg(target_os = "linux")'.dependencies]
 seccompiler = "0.3.0"
 libc = "0.2.132"
+log = "0.4.20"
 
 [dev-dependencies]
 clap = { version = "3.2.17", features = ["derive"] }

--- a/integration/delete_before_lockdown.rs
+++ b/integration/delete_before_lockdown.rs
@@ -1,0 +1,22 @@
+
+use birdcage::{Birdcage, Exception, Sandbox};
+use tempfile::NamedTempFile;
+
+use crate::TestSetup;
+
+pub fn setup() -> TestSetup {
+    // Create temporary file.
+    let tempfile = NamedTempFile::new().unwrap();
+
+    // Setup sandbox exceptions.
+    let mut sandbox = Birdcage::new();
+    sandbox.add_exception(Exception::Read(tempfile.path().into())).unwrap();
+
+    drop(tempfile);
+
+    TestSetup { sandbox, data: String::new() }
+}
+
+pub fn validate(_data: String) {
+    // We just want to test sandbox creation worked.
+}

--- a/integration/delete_before_lockdown.rs
+++ b/integration/delete_before_lockdown.rs
@@ -12,7 +12,7 @@ pub fn setup() -> TestSetup {
     let mut sandbox = Birdcage::new();
     sandbox.add_exception(Exception::Read(tempfile.path().into())).unwrap();
 
-    drop(tempfile);
+    tempfile.close().unwrap();
 
     TestSetup { sandbox, data: String::new() }
 }

--- a/integration/harness.rs
+++ b/integration/harness.rs
@@ -6,6 +6,7 @@ test_mods! {
     mod canonicalize;
     #[cfg(target_os = "linux")]
     mod consistent_id_mappings;
+    mod delete_before_lockdown;
     mod env;
     mod exec;
     mod exec_symlinked_dir;

--- a/src/linux/namespaces.rs
+++ b/src/linux/namespaces.rs
@@ -55,7 +55,10 @@ pub(crate) fn setup_mount_namespace(exceptions: PathExceptions) -> io::Result<()
         let dst_c = CString::new(dst.as_os_str().as_bytes()).unwrap();
 
         // Create mount target.
-        copy_tree(&path, &new_root)?;
+        if let Err(err) = copy_tree(&path, &new_root) {
+            log::error!("skipping birdcage exception {path:?}: {err}");
+            continue;
+        }
 
         // Bind path with full permissions.
         bind_mount(&src_c, &dst_c)?;


### PR DESCRIPTION
This fixes an issue where locking down the Linux sandbox would fail if a
path was deleted after adding the exception but before locking down the
sandbox.