### PR TITLE
Fix conversion to std::process::Command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The sections should follow the order `Packaging`, `Added`, `Changed`, `Fixed` an
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Fixed
+
+- Conversion from Birdcage's to STD's `Command` inheriting all STDIO
+
 ## [0.8.0] - 2024-04-19
 
 ### Changed

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -216,6 +216,9 @@ fn sandbox_init_inner(mut init_arg: ProcessInitArg) -> io::Result<libc::c_int> {
 
     // Spawn sandboxed process.
     let mut std_command = std::process::Command::from(init_arg.sandboxee);
+    std_command.stdin(std::process::Stdio::inherit());
+    std_command.stdout(std::process::Stdio::inherit());
+    std_command.stderr(std::process::Stdio::inherit());
     let child = std_command.spawn()?;
 
     // Reap zombie children.


### PR DESCRIPTION
This fixes an issue with Linux's `birdcage::process::Command` where STDIO was always set to `Stdio::inherit()` when converting to STD's `Command`.