### PR TITLE
ci: use GitHub-hosted macOS runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,9 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: [self-hosted, linux, arm64]
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-14
           - target: aarch64-apple-darwin
-            os: [self-hosted, macos, arm64]
+            os: macos-14
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
   workflow_dispatch:
   pull_request:
   push:
+    branches:
+      - main
+    tags:
+      - '*'
   # Run weekly on the default branch to make sure it always builds with the latest rust release
   schedule:
     - cron: '30 5 * * 1'
@@ -24,7 +28,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        run: rustup toolchain install --no-self-update stable --profile minimal -c clippy
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSfL https://sh.rustup.rs \
+            | sh -s -- -y --default-toolchain stable --profile minimal -c clippy
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Test Stable
         run: cargo +stable test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: [self-hosted, linux, arm64]
           - target: x86_64-apple-darwin
-            os: macos-14
+            os: macos-13
           - target: aarch64-apple-darwin
             os: macos-14
     runs-on: ${{ matrix.os }}
@@ -54,3 +54,16 @@ jobs:
         run: |
           rustup toolchain install nightly -c rustfmt
           cargo +nightly fmt -- --check
+
+  # This job reports the results of the test jobs above and is used
+  # to enforce status checks in the repo settings without needing
+  # to update those settings every time the test jobs are updated.
+  test-rollup:
+    name: Test rollup
+    runs-on: ubuntu-latest
+    if: always()
+    needs: test-matrix
+    steps:
+      - name: Check for test jobs failure or cancellation
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,43 +14,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-          - target: aarch64-unknown-linux-gnu
-            os: [self-hosted, linux, arm64]
-          - target: x86_64-apple-darwin
-            os: macos-13
-          - target: aarch64-apple-darwin
-            os: macos-14
+        os:
+          - ubuntu-latest
+          - [self-hosted, linux, arm64]
+          - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: ${{ matrix.target }}
-          profile: minimal
+        run: rustup toolchain install --no-self-update stable --profile minimal -c clippy
 
       - name: Test Stable
-        run: cargo test
+        run: cargo +stable test
 
       - name: Test Oldstable
         run: |
           oldstable=$(cat Cargo.toml | grep rust-version | sed 's/.*"\(.*\)".*/\1/')
           rustup toolchain install --profile minimal $oldstable
-          rustup default $oldstable
-          cargo test
+          cargo "+$oldstable" test
 
       - name: Clippy
-        run: |
-          rustup component add clippy
-          cargo clippy
+        run: cargo +stable clippy
 
-      - name : Rustfmt
+      - name: Rustfmt
         run: |
           rustup toolchain install nightly -c rustfmt
           cargo +nightly fmt -- --check


### PR DESCRIPTION
The GitHub-hosted macOS runners have been updated to include arm64 M1 options now. This PR switches our workflows to use them instead of the self-hosted runner. There is more availability for these runners and they run just about as fast, if not faster when accounting for parallel jobs. The workflow was updated to change `macos-latest` to `macos-14` to be specific about the version in the matrix and allow for adding additional versions in the future.

Resources:
* [Standard GitHub-hosted runners for public repos](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
* [Latest `macos-14` image release](https://github.com/actions/runner-images/releases/tag/macos-14-arm64%2F20240701.9)
* [SW included in latest `macos-14` image](https://github.com/actions/runner-images/blob/macos-14-arm64/20240701.9/images/macos/macos-14-arm64-Readme.md)

