### PR TITLE
feat: linux spawn wait for lock instead of panicking

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,8 +81,6 @@ pub trait Sandbox: Sized {
     ///
     /// # Errors
     ///
-    /// Sandboxing will fail if the calling process is not single-threaded.
-    ///
     /// After failure, the calling process might still be affected by partial
     /// sandboxing restrictions.
     fn spawn(self, sandboxee: Command) -> Result<Child>;

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -7,7 +7,7 @@ use std::os::fd::OwnedFd;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Mutex;
-use std::{env, fs, io, ptr};
+use std::{env, io, ptr};
 
 use rustix::pipe::pipe;
 use rustix::process::{Gid, Pid, Uid, WaitOptions};

--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -419,24 +419,3 @@ fn normalize_path(path: &Path) -> PathBuf {
 fn path_has_symlinks(path: &Path) -> bool {
     path.ancestors().any(|path| path.read_link().is_ok())
 }
-
-/// Get the number of threads used by the current process.
-fn thread_count() -> io::Result<usize> {
-    // Read process status from procfs.
-    let status = fs::read_to_string("/proc/self/status")?;
-
-    // Parse procfs output.
-    let (_, threads_start) = status.split_once("Threads:").ok_or_else(|| {
-        io::Error::new(io::ErrorKind::InvalidData, "/proc/self/status missing \"Threads:\"")
-    })?;
-    let thread_count = threads_start.split_whitespace().next().ok_or_else(|| {
-        io::Error::new(io::ErrorKind::InvalidData, "/proc/self/status output malformed")
-    })?;
-
-    // Convert to number.
-    let thread_count = thread_count
-        .parse::<usize>()
-        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
-
-    Ok(thread_count)
-}


### PR DESCRIPTION
By adding a lock, multithreaded programs can still use this API

- added lock
- adapted docs
- removed unused function

@baszalmstra

<!--
Before submitting a PR:

1. Link the associated issue (i.e., `closes #<issueNum>` in description)
2. Ensure that you have met the expected acceptance criteria
3. Ensure that you have created sufficient tests
4. Ensure that you have updated all affected documentation
-->

